### PR TITLE
이미지 삭제 로직 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,10 +13,11 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Hippho"
-        tools:ignore="AllowBackup,GoogleAppIndexingWarning">
+        tools:ignore="AllowBackup,GoogleAppIndexingWarning,UnusedAttribute">
         <activity
             android:name="com.anliban.team.hippho.ui.MainActivity"
             android:launchMode="singleTop">

--- a/app/src/main/java/com/anliban/team/hippho/data/MediaProvider.kt
+++ b/app/src/main/java/com/anliban/team/hippho/data/MediaProvider.kt
@@ -89,7 +89,6 @@ class MediaProviderImpl(context: Context) : MediaProvider {
 
             contentResolver.applyBatch(AUTHORITY, operations)
         }
-
     }
 
     private suspend fun Cursor?.search(): List<Image> {

--- a/app/src/main/java/com/anliban/team/hippho/di/module/AppModule.kt
+++ b/app/src/main/java/com/anliban/team/hippho/di/module/AppModule.kt
@@ -3,8 +3,8 @@ package com.anliban.team.hippho.di.module
 import android.app.Application
 import android.content.Context
 import com.anliban.team.hippho.HipphoApp
-import com.anliban.team.hippho.data.ImageLoader
-import com.anliban.team.hippho.data.ImageLoaderImpl
+import com.anliban.team.hippho.data.MediaProvider
+import com.anliban.team.hippho.data.MediaProviderImpl
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -21,5 +21,5 @@ class AppModule {
     fun provideApplication(): Application = HipphoApp()
 
     @Provides
-    fun provideImageLoader(context: Context): ImageLoader = ImageLoaderImpl(context)
+    fun provideMediaProvider(context: Context): MediaProvider = MediaProviderImpl(context)
 }

--- a/app/src/main/java/com/anliban/team/hippho/domain/DeleteImageUseCase.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/DeleteImageUseCase.kt
@@ -1,0 +1,11 @@
+package com.anliban.team.hippho.domain
+
+import com.anliban.team.hippho.data.MediaProvider
+import com.anliban.team.hippho.model.Image
+
+class DeleteImageUseCase(private val mediaProvider: MediaProvider) {
+
+    suspend fun execute(parameters: List<Image>) {
+        mediaProvider.delete(parameters)
+    }
+}

--- a/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
@@ -30,4 +30,7 @@ class DomainModule {
 
     @Provides
     fun provideImageLoadHelper(): ImageLoadHelper = ImageLoadHelper()
+
+    @Provides
+    fun provideDeleteImageUseCase(mediaProvider: MediaProvider): DeleteImageUseCase = DeleteImageUseCase(mediaProvider)
 }

--- a/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
@@ -1,7 +1,7 @@
 package com.anliban.team.hippho.domain
 
 import com.anliban.team.hippho.data.ImageLoadHelper
-import com.anliban.team.hippho.data.ImageLoader
+import com.anliban.team.hippho.data.MediaProvider
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimUseCase
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionUseCase
 import dagger.Module
@@ -12,15 +12,15 @@ class DomainModule {
 
     @Provides
     fun provideGetImageByDateUseCase(
-        imageLoader: ImageLoader,
+        mediaProvider: MediaProvider,
         imageLoaderHelper: ImageLoadHelper
     ): GetImageByDateUseCase =
-        GetImageByDateUseCase(imageLoader, imageLoaderHelper)
+        GetImageByDateUseCase(mediaProvider, imageLoaderHelper)
 
     @Provides
     fun provideGetImageByIdUseCase(
-        imageLoader: ImageLoader
-    ): GetImageByIdUseCase = GetImageByIdUseCase(imageLoader)
+        mediaProvider: MediaProvider
+    ): GetImageByIdUseCase = GetImageByIdUseCase(mediaProvider)
 
     @Provides
     fun provideSwitchImagePositionUseCase(): SwitchImagePositionUseCase = SwitchImagePositionUseCase()

--- a/app/src/main/java/com/anliban/team/hippho/domain/GetImageByDateUseCase.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/GetImageByDateUseCase.kt
@@ -1,6 +1,6 @@
 package com.anliban.team.hippho.domain
 import com.anliban.team.hippho.data.ImageLoadHelper
-import com.anliban.team.hippho.data.ImageLoader
+import com.anliban.team.hippho.data.MediaProvider
 import com.anliban.team.hippho.domain.model.GetImageRequestParameters
 import com.anliban.team.hippho.ui.home.HomeListContent
 import com.anliban.team.hippho.ui.home.HomeListHeader
@@ -10,12 +10,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class GetImageByDateUseCase(
-    private val imageLoader: ImageLoader,
+    private val mediaProvider: MediaProvider,
     private val imageLoadHelper: ImageLoadHelper
 ) : FlowUseCase<GetImageRequestParameters, List<HomeUiModel>>() {
 
     override fun execute(parameters: GetImageRequestParameters): Flow<List<HomeUiModel>> {
-        return imageLoader.getImages(parameters.option)
+        return mediaProvider.getImages(parameters.option)
             .map { images ->
                 images.groupBy { it.date.midNight() }
                     .flatMap { imageLoadHelper.groupByTimeInterval(it.key, it.value) }

--- a/app/src/main/java/com/anliban/team/hippho/domain/GetImageByIdUseCase.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/GetImageByIdUseCase.kt
@@ -1,15 +1,15 @@
 package com.anliban.team.hippho.domain
 
-import com.anliban.team.hippho.data.ImageLoader
+import com.anliban.team.hippho.data.MediaProvider
 import com.anliban.team.hippho.domain.model.GetImageRequestParameters
 import com.anliban.team.hippho.model.Image
 import kotlinx.coroutines.flow.Flow
 
 class GetImageByIdUseCase(
-    private val imageLoader: ImageLoader
+    private val mediaProvider: MediaProvider
 ) : FlowUseCase<GetImageRequestParameters, List<Image>>() {
 
     override fun execute(parameters: GetImageRequestParameters): Flow<List<Image>> {
-        return imageLoader.getImages(parameters.option, parameters.ids)
+        return mediaProvider.getImages(parameters.option, parameters.ids)
     }
 }

--- a/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailFragment.kt
@@ -86,7 +86,14 @@ class DetailFragment : DaggerFragment() {
         }
 
         viewModel.navigateToHome.observe(viewLifecycleOwner, EventObserver {
-            findNavController().popBackStack()
+            findNavController().run {
+                previousBackStackEntry?.savedStateHandle?.set(EXT_REFRESH, true)
+                popBackStack()
+            }
         })
+    }
+
+    private companion object {
+        private const val EXT_REFRESH = "refreshing"
     }
 }

--- a/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailFragment.kt
@@ -88,7 +88,5 @@ class DetailFragment : DaggerFragment() {
         viewModel.navigateToHome.observe(viewLifecycleOwner, EventObserver {
             findNavController().popBackStack()
         })
-
-        //    viewModel.setSharedElement(args.images.toList())
     }
 }

--- a/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.anliban.team.hippho.data.ImageQueryOption
+import com.anliban.team.hippho.domain.DeleteImageUseCase
 import com.anliban.team.hippho.domain.GetImageByIdUseCase
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimRequestParameters
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimUseCase
@@ -26,6 +27,7 @@ class DetailViewModel @AssistedInject constructor(
     private val getImageByDateUseCase: GetImageByIdUseCase,
     private val switchImagePositionUseCase: SwitchImagePositionUseCase,
     private val scaleImageAnimUseCase: ScaleImageAnimUseCase,
+    private val deleteImageUseCase: DeleteImageUseCase,
     @Assisted private val ids: LongArray
 ) : ViewModel() {
 
@@ -130,8 +132,15 @@ class DetailViewModel @AssistedInject constructor(
     }
 
     fun organizeImage() {
-        viewModelScope.launch {
-            _navigateToHome.value = Event(Unit)
+        val images = _secondLists.value
+            ?.filter { it.isScaled }
+            ?.map { it.image }
+
+        images?.let {
+            viewModelScope.launch {
+                deleteImageUseCase.execute(it)
+                _navigateToHome.value = Event(Unit)
+            }
         }
     }
 

--- a/app/src/main/java/com/anliban/team/hippho/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/home/HomeFragment.kt
@@ -6,8 +6,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.findNavController
+import androidx.navigation.fragment.findNavController
 import com.anliban.team.hippho.R
 import com.anliban.team.hippho.databinding.FragmentHomeBinding
 import com.anliban.team.hippho.ui.home.adapter.HomeAdapter
@@ -52,6 +54,18 @@ class HomeFragment : DaggerFragment() {
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        findNavController().currentBackStackEntry
+            ?.savedStateHandle?.getLiveData<Boolean>(EXT_REFRESH)
+            ?.observe(viewLifecycleOwner, Observer {
+                if (it) {
+                    viewModel.onSwipeRefresh()
+                }
+            })
+    }
+
     private fun requestPermissions() {
         TedPermission.with(requireContext())
             .setPermissionListener(object : PermissionListener {
@@ -80,5 +94,9 @@ class HomeFragment : DaggerFragment() {
         }
 
         return result
+    }
+
+    private companion object {
+        private const val EXT_REFRESH = "refreshing"
     }
 }


### PR DESCRIPTION
issue - closed #4 

### 이미지 삭제 구현

안드로이드 10부터 적용된, scoped storage로 인하여 이미지가 개별적으로 삭제되는 이슈로 인하여 `requestLegacyExternalStorage` 을 사용하여 scoped storage 무시 
- 안드로이드 11(R) 부터는 `scoped storage`가 필수로 적용되고, `createDeleteRequest()`를 제공하여 다중 삭제가 추가됨

- 삭제 될 시, 홈 리스트 갱신 처리