### PR TITLE
SharedPreference에 삭제한 이미지 갯수, 용량 저장하는 로직 및 화면 구현

### DIFF
--- a/app/src/main/java/com/anliban/team/hippho/data/MediaProvider.kt
+++ b/app/src/main/java/com/anliban/team/hippho/data/MediaProvider.kt
@@ -8,9 +8,7 @@ import android.os.Build
 import android.provider.MediaStore
 import android.provider.MediaStore.AUTHORITY
 import com.anliban.team.hippho.model.Image
-import com.anliban.team.hippho.util.bytesToMegaBytes
 import com.anliban.team.hippho.util.dateToTimestamp
-import com.anliban.team.hippho.util.roundTo2Decimal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -126,7 +124,7 @@ class MediaProviderImpl(context: Context) : MediaProvider {
             } else {
                 Date(getLong(dateColumn) * 1000)
             }
-        val fileSize = bytesToMegaBytes(getString(fileSizeColumn)).roundTo2Decimal()
+        val fileSize = getLong(fileSizeColumn)
 
         Timber.i("Name : $displayName / Date : $dateTaken / ID : $id / path : $contentUri / size : $fileSize")
 

--- a/app/src/main/java/com/anliban/team/hippho/data/pref/PreferenceStorage.kt
+++ b/app/src/main/java/com/anliban/team/hippho/data/pref/PreferenceStorage.kt
@@ -1,0 +1,49 @@
+package com.anliban.team.hippho.data.pref
+
+import android.content.Context
+import android.content.Context.MODE_PRIVATE
+import android.content.SharedPreferences
+import androidx.annotation.WorkerThread
+import androidx.core.content.edit
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+interface PreferenceStorage {
+    var deletedCount: Long
+    var deletedFileSize: Long
+}
+
+class SharedPreferenceStorage(context: Context) : PreferenceStorage {
+
+    private val prefs: Lazy<SharedPreferences> = lazy {
+        context.applicationContext.getSharedPreferences(
+            PREFS_NAME, MODE_PRIVATE
+        )
+    }
+
+    override var deletedCount: Long by LongPreference(prefs, PREF_DELETED_COUNT, 0)
+
+    override var deletedFileSize: Long by LongPreference(prefs, PREF_DELETED_FILE_SIZE, 0)
+
+    companion object {
+        const val PREFS_NAME = "hippho"
+        const val PREF_DELETED_COUNT = "pref_deleted_count"
+        const val PREF_DELETED_FILE_SIZE = "pref_deleted_file_size"
+    }
+}
+
+class LongPreference(
+    private val preferences: Lazy<SharedPreferences>,
+    private val name: String,
+    private val defaultValue: Long
+) : ReadWriteProperty<Any, Long> {
+
+    @WorkerThread
+    override fun getValue(thisRef: Any, property: KProperty<*>): Long {
+        return preferences.value.getLong(name, defaultValue)
+    }
+
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: Long) {
+        preferences.value.edit { putLong(name, value) }
+    }
+}

--- a/app/src/main/java/com/anliban/team/hippho/di/module/AppModule.kt
+++ b/app/src/main/java/com/anliban/team/hippho/di/module/AppModule.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import com.anliban.team.hippho.HipphoApp
 import com.anliban.team.hippho.data.MediaProvider
 import com.anliban.team.hippho.data.MediaProviderImpl
+import com.anliban.team.hippho.data.pref.PreferenceStorage
+import com.anliban.team.hippho.data.pref.SharedPreferenceStorage
 import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
@@ -22,4 +24,9 @@ class AppModule {
 
     @Provides
     fun provideMediaProvider(context: Context): MediaProvider = MediaProviderImpl(context)
+
+    @Singleton
+    @Provides
+    fun providePreferenceStorage(context: Context): PreferenceStorage =
+        SharedPreferenceStorage(context)
 }

--- a/app/src/main/java/com/anliban/team/hippho/domain/DeleteImageUseCase.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/DeleteImageUseCase.kt
@@ -1,11 +1,26 @@
 package com.anliban.team.hippho.domain
 
 import com.anliban.team.hippho.data.MediaProvider
+import com.anliban.team.hippho.data.pref.PreferenceStorage
 import com.anliban.team.hippho.model.Image
 
-class DeleteImageUseCase(private val mediaProvider: MediaProvider) {
+class DeleteImageUseCase(
+    private val mediaProvider: MediaProvider,
+    private val preferenceStorage: PreferenceStorage
+) {
 
     suspend fun execute(parameters: List<Image>) {
-        mediaProvider.delete(parameters)
+        try {
+            mediaProvider.delete(parameters)
+            updateDeletedStorage(parameters)
+        } catch (e: Exception) {
+        }
+    }
+
+    private fun updateDeletedStorage(images: List<Image>) {
+        images.forEach {
+            preferenceStorage.deletedCount += 1
+            preferenceStorage.deletedFileSize += it.fileSize
+        }
     }
 }

--- a/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
@@ -5,6 +5,7 @@ import com.anliban.team.hippho.data.MediaProvider
 import com.anliban.team.hippho.data.pref.PreferenceStorage
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimUseCase
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionUseCase
+import com.anliban.team.hippho.domain.info.LoadInfoDataUseCase
 import dagger.Module
 import dagger.Provides
 
@@ -38,4 +39,9 @@ class DomainModule {
         mediaProvider: MediaProvider,
         preferenceStorage: PreferenceStorage
     ): DeleteImageUseCase = DeleteImageUseCase(mediaProvider, preferenceStorage)
+
+    @Provides
+    fun provideLoadInfoDataUseCase(
+        preferenceStorage: PreferenceStorage
+    ): LoadInfoDataUseCase = LoadInfoDataUseCase(preferenceStorage)
 }

--- a/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
@@ -2,6 +2,7 @@ package com.anliban.team.hippho.domain
 
 import com.anliban.team.hippho.data.ImageLoadHelper
 import com.anliban.team.hippho.data.MediaProvider
+import com.anliban.team.hippho.data.pref.PreferenceStorage
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimUseCase
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionUseCase
 import dagger.Module
@@ -23,7 +24,8 @@ class DomainModule {
     ): GetImageByIdUseCase = GetImageByIdUseCase(mediaProvider)
 
     @Provides
-    fun provideSwitchImagePositionUseCase(): SwitchImagePositionUseCase = SwitchImagePositionUseCase()
+    fun provideSwitchImagePositionUseCase(): SwitchImagePositionUseCase =
+        SwitchImagePositionUseCase()
 
     @Provides
     fun provideScaleImageAnimUseCase(): ScaleImageAnimUseCase = ScaleImageAnimUseCase()
@@ -32,5 +34,8 @@ class DomainModule {
     fun provideImageLoadHelper(): ImageLoadHelper = ImageLoadHelper()
 
     @Provides
-    fun provideDeleteImageUseCase(mediaProvider: MediaProvider): DeleteImageUseCase = DeleteImageUseCase(mediaProvider)
+    fun provideDeleteImageUseCase(
+        mediaProvider: MediaProvider,
+        preferenceStorage: PreferenceStorage
+    ): DeleteImageUseCase = DeleteImageUseCase(mediaProvider, preferenceStorage)
 }

--- a/app/src/main/java/com/anliban/team/hippho/domain/info/LoadInfoDataUseCase.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/info/LoadInfoDataUseCase.kt
@@ -1,0 +1,20 @@
+package com.anliban.team.hippho.domain.info
+
+import com.anliban.team.hippho.data.pref.PreferenceStorage
+import com.anliban.team.hippho.domain.UseCase
+
+class LoadInfoDataUseCase(
+    private val preferenceStorage: PreferenceStorage
+) : UseCase<Unit, LoadInfoDataResult>() {
+    override fun execute(parameters: Unit): LoadInfoDataResult {
+        return LoadInfoDataResult(
+            deletedImageCount = preferenceStorage.deletedCount,
+            deletedFileSize = preferenceStorage.deletedFileSize
+        )
+    }
+}
+
+data class LoadInfoDataResult(
+    val deletedImageCount: Long,
+    val deletedFileSize: Long
+)

--- a/app/src/main/java/com/anliban/team/hippho/ui/info/InfoViewModel.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/info/InfoViewModel.kt
@@ -21,6 +21,7 @@ class InfoViewModel @Inject constructor(
     }
 
     val deletedMemoryCount: LiveData<String> = Transformations.map(loadInfoResult) {
+        println(it)
         it.deletedFileSize.bytesToMegaBytes().toDecimal()
     }
 

--- a/app/src/main/java/com/anliban/team/hippho/ui/info/InfoViewModel.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/info/InfoViewModel.kt
@@ -1,30 +1,30 @@
 package com.anliban.team.hippho.ui.info
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
+import com.anliban.team.hippho.domain.info.LoadInfoDataResult
+import com.anliban.team.hippho.domain.info.LoadInfoDataUseCase
+import com.anliban.team.hippho.util.bytesToMegaBytes
+import com.anliban.team.hippho.util.toDecimal
 import javax.inject.Inject
 
-class InfoViewModel @Inject constructor() : ViewModel() {
+class InfoViewModel @Inject constructor(
+    loadInfoDataUseCase: LoadInfoDataUseCase
+) : ViewModel() {
 
-    private val _deletedPhotoCount = MutableLiveData<Int>()
-    val deletedPhotoCount: LiveData<Int>
-        get() = _deletedPhotoCount
+    private val loadInfoResult = MediatorLiveData<LoadInfoDataResult>()
 
-    private val _deletedMemoryCount = MutableLiveData<Double>()
-    val deletedMemoryCount: LiveData<Double>
-        get() = _deletedMemoryCount
+    val deletedPhotoCount: LiveData<String> = Transformations.map(loadInfoResult) {
+        it.deletedImageCount.toDouble().toDecimal()
+    }
+
+    val deletedMemoryCount: LiveData<String> = Transformations.map(loadInfoResult) {
+        it.deletedFileSize.bytesToMegaBytes().toDecimal()
+    }
 
     init {
-        loadDeletedPhotoCount()
-        loadDeletedMemoryCount()
-    }
-
-    fun loadDeletedPhotoCount() {
-        _deletedPhotoCount.postValue(10)
-    }
-
-    fun loadDeletedMemoryCount() {
-        _deletedMemoryCount.postValue(12.5)
+        loadInfoDataUseCase(Unit, loadInfoResult)
     }
 }

--- a/app/src/main/java/com/anliban/team/hippho/util/StringUtil.kt
+++ b/app/src/main/java/com/anliban/team/hippho/util/StringUtil.kt
@@ -1,9 +1,13 @@
 package com.anliban.team.hippho.util
 
+import java.text.NumberFormat
+
 /**
  * Created by choejun-yeong on 14/04/2020.
  */
 
-fun bytesToMegaBytes(number: String): Double {
-    return number.toDouble() / 1024 / 1024
+fun Number.bytesToMegaBytes(): Double {
+    return toDouble() / 1024 / 1024
 }
+
+fun Number.toDecimal(): String = NumberFormat.getInstance().format(this)

--- a/app/src/main/res/layout/fragment_info.xml
+++ b/app/src/main/res/layout/fragment_info.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="viewModel"
             type="com.anliban.team.hippho.ui.info.InfoViewModel" />
     </data>
-
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -17,61 +18,57 @@
             android:id="@+id/info_divider"
             android:layout_width="@dimen/match_constraint"
             android:layout_height="1dp"
-            app:layout_constraintTop_toTopOf="parent"
+            android:background="@color/gray"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            android:background="@color/gray"
-            />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/info_deleted_photo_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/text_large"
-            android:text="@string/deleted_photo_text"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
-            android:layout_marginTop="@dimen/space_large"
             android:layout_marginStart="@dimen/space_large"
-            />
+            android:layout_marginTop="@dimen/space_large"
+            android:text="@string/deleted_photo_text"
+            android:textSize="@dimen/text_large"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/info_deleted_photo_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="@{@string/deleted_photo_format(viewModel.deletedPhotoCount)}"
             android:textSize="@dimen/text_large"
-            android:text='@{viewModel.deletedPhotoCount+"장"}'
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="@id/info_divider"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="120 " />
 
         <TextView
             android:id="@+id/info_deleted_memory_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/text_large"
-            android:text="@string/deleted_memory_text"
-            app:layout_constraintTop_toTopOf="@id/info_divider"
-            app:layout_constraintLeft_toLeftOf="parent"
-            android:layout_marginTop="@dimen/space_large"
             android:layout_marginStart="@dimen/space_large"
-            />
+            android:layout_marginTop="@dimen/space_large"
+            android:text="@string/deleted_memory_text"
+            android:textSize="@dimen/text_large"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintTop_toTopOf="@id/info_divider" />
 
         <TextView
             android:id="@+id/info_deleted_memory_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:text="@{@string/deleted_memory_format(viewModel.deletedMemoryCount)}"
             android:textSize="@dimen/text_large"
-            android:text='@{viewModel.deletedMemoryCount+"MB"}'
-            app:layout_constraintTop_toTopOf="@id/info_divider"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            />
-
+            app:layout_constraintTop_toTopOf="@id/info_divider"
+            tools:text="13,000 MB" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,8 @@
 
     <string name="deleted_photo_text">지운 사진 수</string>
     <string name="deleted_memory_text">비운 용량</string>
+
+    <!-- Info -->
+    <string name="deleted_photo_format" >%s 장</string>
+    <string name="deleted_memory_format">%s MB</string>
 </resources>

--- a/app/src/test/java/com/anliban/team/hippho/domain/info/LoadInfoDataUseCaseTest.kt
+++ b/app/src/test/java/com/anliban/team/hippho/domain/info/LoadInfoDataUseCaseTest.kt
@@ -1,0 +1,45 @@
+package com.anliban.team.hippho.domain.info
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import com.anliban.team.hippho.MockkRule
+import com.anliban.team.hippho.data.pref.PreferenceStorage
+import com.anliban.team.hippho.getOrAwaitValue
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Rule
+import org.junit.Test
+
+class LoadInfoDataUseCaseTest {
+
+    @get:Rule
+    val instantRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mockkRule = MockkRule(this)
+
+    lateinit var useCase: LoadInfoDataUseCase
+
+    @MockK(relaxed = true)
+    lateinit var preferenceStorage: PreferenceStorage
+
+    @Test
+    fun `지운 사진 갯수, 용량 데이터 로드`() {
+        useCase = LoadInfoDataUseCase(preferenceStorage)
+
+        every {
+            preferenceStorage.deletedCount
+        } returns 0L
+
+        every {
+            preferenceStorage.deletedFileSize
+        } returns 0L
+
+        val result = MutableLiveData<LoadInfoDataResult>()
+
+        useCase.invoke(Unit, result)
+
+        assert(result.getOrAwaitValue().deletedImageCount == 0L)
+        assert(result.getOrAwaitValue().deletedFileSize == 0L)
+    }
+}

--- a/app/src/test/java/com/anliban/team/hippho/ui/info/InfoViewModelTest.kt
+++ b/app/src/test/java/com/anliban/team/hippho/ui/info/InfoViewModelTest.kt
@@ -1,0 +1,56 @@
+package com.anliban.team.hippho.ui.info
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.anliban.team.hippho.MockkRule
+import com.anliban.team.hippho.data.pref.PreferenceStorage
+import com.anliban.team.hippho.domain.info.LoadInfoDataResult
+import com.anliban.team.hippho.domain.info.LoadInfoDataUseCase
+import com.anliban.team.hippho.getOrAwaitValue
+import com.anliban.team.hippho.util.bytesToMegaBytes
+import com.anliban.team.hippho.util.toDecimal
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Rule
+import org.junit.Test
+
+class InfoViewModelTest {
+
+    @get:Rule
+    val instantRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mockkRule = MockkRule(this)
+
+    lateinit var viewModel: InfoViewModel
+
+    @Test
+    fun `지운사진 및 이미지 데이터 로드`() {
+
+        val infoDataResult = LoadInfoDataResult(2, 2048)
+        viewModel = createViewModel()
+
+        assert(
+            viewModel.deletedMemoryCount.getOrAwaitValue() ==
+                    infoDataResult.deletedFileSize.bytesToMegaBytes().toDecimal()
+        )
+
+        assert(
+            viewModel.deletedPhotoCount.getOrAwaitValue() ==
+                    infoDataResult.deletedImageCount.toDouble().toDecimal()
+        )
+    }
+
+    private fun createViewModel(): InfoViewModel {
+        val preferenceStorage = mockk<PreferenceStorage>(relaxed = true)
+        every {
+            preferenceStorage.deletedCount
+        } returns 2
+
+        every {
+            preferenceStorage.deletedFileSize
+        } returns 2048
+        return InfoViewModel(
+            loadInfoDataUseCase = LoadInfoDataUseCase(preferenceStorage)
+        )
+    }
+}

--- a/model/src/main/java/com/anliban/team/hippho/model/Image.kt
+++ b/model/src/main/java/com/anliban/team/hippho/model/Image.kt
@@ -14,5 +14,5 @@ data class Image(
     val fileName: String,
     val date: Date,
     val contentUri: String,
-    val fileSize: Double
+    val fileSize: Long
 ) : Parcelable


### PR DESCRIPTION
issue - closed #24 

- mediaprovider에서 이미지에 byte를 저장하도록 수정 ( info 또는 다른 화면에서 mb, gb등 여러가지고 매핑해서 사용할 수 있도록)
- 이미지 크기, 갯수 sharedPreference 저장 로직 구현
- 이미지 삭제 시, preference에 갯수, 크기를 업데이트 하는 로직 구현
- InfoViewModel, LoadInfoDataUseCase 데이터 로드 테스트 작성