### PR TITLE
Detail페이지 상단(Recycler)사진과 하단사진 Indicator 싱크 맞지 않는 현상 수정

### DIFF
--- a/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/DomainModule.kt
@@ -4,6 +4,7 @@ import com.anliban.team.hippho.data.ImageLoadHelper
 import com.anliban.team.hippho.data.MediaProvider
 import com.anliban.team.hippho.data.pref.PreferenceStorage
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimUseCase
+import com.anliban.team.hippho.domain.detail.SwitchImageIndicatorUseCase
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionUseCase
 import com.anliban.team.hippho.domain.info.LoadInfoDataUseCase
 import dagger.Module
@@ -27,6 +28,10 @@ class DomainModule {
     @Provides
     fun provideSwitchImagePositionUseCase(): SwitchImagePositionUseCase =
         SwitchImagePositionUseCase()
+
+    @Provides
+    fun provideSwitchImageIndicatorUseCase(): SwitchImageIndicatorUseCase =
+        SwitchImageIndicatorUseCase()
 
     @Provides
     fun provideScaleImageAnimUseCase(): ScaleImageAnimUseCase = ScaleImageAnimUseCase()

--- a/app/src/main/java/com/anliban/team/hippho/domain/detail/SwitchImageIndicatorUseCase.kt
+++ b/app/src/main/java/com/anliban/team/hippho/domain/detail/SwitchImageIndicatorUseCase.kt
@@ -1,0 +1,41 @@
+package com.anliban.team.hippho.domain.detail
+
+import androidx.lifecycle.MutableLiveData
+import com.anliban.team.hippho.domain.UseCase
+import com.anliban.team.hippho.ui.detail.DetailImage
+
+/**
+ * Created by choejun-yeong on 24/04/2020.
+ */
+
+class SwitchImageIndicatorUseCase :
+    UseCase<SwitchImageIndicatorRequestParameters, List<DetailImage>>() {
+
+    override fun execute(parameters: SwitchImageIndicatorRequestParameters): List<DetailImage> {
+
+        val clickedId = parameters.clickedId
+        val position = parameters.position
+        val result = parameters.items?.toMutableList() ?: mutableListOf()
+
+        if (result[position].isSelected) {
+            return parameters.items ?: emptyList()
+        }
+
+        result.find { it.isSelected }?.let {
+            val originPosition = result.indexOf(it)
+            result[originPosition] =
+                result[originPosition].copy(isSelected = false, isScaled = it.isScaled)
+        }
+
+        result[position] = result[position].copy(isSelected = true)
+        clickedId.value = result[position].image.id
+
+        return result
+    }
+}
+
+data class SwitchImageIndicatorRequestParameters(
+    val position: Int,
+    val items: List<DetailImage>?,
+    val clickedId: MutableLiveData<Long>
+)

--- a/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailBindingAdapter.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailBindingAdapter.kt
@@ -17,7 +17,7 @@ fun RecyclerView.bindDetailImages(items: List<DetailUiModel>?) {
 @BindingAdapter("moveToItem")
 fun RecyclerView.moveToItem(position: Event<Int>?) {
     val movePosition = position?.getContentIfNotHandled() ?: return
-    smoothScrollToPosition(movePosition)
+    scrollToPosition(movePosition)
 }
 
 @BindingAdapter(value = ["organizeState", "imageType"], requireAll = true)

--- a/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailFragment.kt
@@ -12,15 +12,17 @@ import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import androidx.recyclerview.widget.LinearSnapHelper
+import androidx.recyclerview.widget.PagerSnapHelper
 import androidx.recyclerview.widget.SimpleItemAnimator
 import com.anliban.team.hippho.R
 import com.anliban.team.hippho.databinding.FragmentDetailBinding
 import com.anliban.team.hippho.model.EventObserver
 import com.anliban.team.hippho.ui.home.adapter.ImageMarginItemDecoration
+import com.anliban.team.hippho.util.attachSnapHelperWithListener
 import com.anliban.team.hippho.util.dp2px
 import com.anliban.team.hippho.util.showSnackBar
 import com.anliban.team.hippho.util.viewModel
+import com.anliban.team.hippho.widget.OnSnapPositionChangeListener
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.android.support.DaggerFragment
 import dev.chrisbanes.insetter.doOnApplyWindowInsets
@@ -83,13 +85,20 @@ class DetailFragment : DaggerFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val thumbnailSnapHelper = LinearSnapHelper()
+        val thumbnailSnapHelper = PagerSnapHelper()
+        val onSnapPositionChangeListener = object : OnSnapPositionChangeListener {
+            override fun onSnapPositionChange(position: Int) {
+                viewModel.changeIndicatorOfSecondList(position)
+            }
+        }
 
         binding.thumbnailRecyclerView.apply {
             adapter = DetailImageAdapter(viewLifecycleOwner, viewModel, DetailListType.Thumb)
+            attachSnapHelperWithListener(
+                thumbnailSnapHelper,
+                onSnapPositionChangeListener = onSnapPositionChangeListener
+            )
         }
-
-        thumbnailSnapHelper.attachToRecyclerView(binding.thumbnailRecyclerView)
 
         binding.secondRecyclerView.apply {
             adapter = DetailImageAdapter(viewLifecycleOwner, viewModel, DetailListType.Second)

--- a/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/anliban/team/hippho/ui/detail/DetailViewModel.kt
@@ -10,6 +10,8 @@ import com.anliban.team.hippho.domain.DeleteImageUseCase
 import com.anliban.team.hippho.domain.GetImageByIdUseCase
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimRequestParameters
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimUseCase
+import com.anliban.team.hippho.domain.detail.SwitchImageIndicatorRequestParameters
+import com.anliban.team.hippho.domain.detail.SwitchImageIndicatorUseCase
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionRequestParameters
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionUseCase
 import com.anliban.team.hippho.domain.model.GetImageRequestParameters
@@ -26,6 +28,7 @@ import kotlinx.coroutines.launch
 class DetailViewModel @AssistedInject constructor(
     private val getImageByDateUseCase: GetImageByIdUseCase,
     private val switchImagePositionUseCase: SwitchImagePositionUseCase,
+    private val switchImageIndicatorUseCase: SwitchImageIndicatorUseCase,
     private val scaleImageAnimUseCase: ScaleImageAnimUseCase,
     private val deleteImageUseCase: DeleteImageUseCase,
     @Assisted private val ids: LongArray
@@ -116,6 +119,15 @@ class DetailViewModel @AssistedInject constructor(
         val thumbnails = requireNotNull(_thumbnails.value)
         val position = thumbnails.indexOf(thumbnails.find { it.image == item.image })
         _moveToThumbnail.value = Event(position)
+    }
+
+    fun changeIndicatorOfSecondList(position: Int) {
+        val request = SwitchImageIndicatorRequestParameters(
+            position,
+            items = _secondLists.value,
+            clickedId = clickedId
+        )
+        switchImageIndicatorUseCase(request, _secondLists)
     }
 
     fun selectImage() {

--- a/app/src/main/java/com/anliban/team/hippho/util/Extensions.kt
+++ b/app/src/main/java/com/anliban/team/hippho/util/Extensions.kt
@@ -10,6 +10,10 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SnapHelper
+import com.anliban.team.hippho.widget.OnSnapPositionChangeListener
+import com.anliban.team.hippho.widget.SnapOnScrollListener
 import com.google.android.material.snackbar.Snackbar
 import java.math.BigDecimal
 
@@ -81,4 +85,21 @@ fun Fragment.showSnackBar(message: String) {
         message,
         Snackbar.LENGTH_SHORT
     ).show()
+}
+
+fun RecyclerView.attachSnapHelperWithListener(
+    snapHelper: SnapHelper,
+    behavior: SnapOnScrollListener.Behavior = SnapOnScrollListener.Behavior.NOTIFY_ON_SCROLL,
+    onSnapPositionChangeListener: OnSnapPositionChangeListener
+) {
+    snapHelper.attachToRecyclerView(this)
+    val snapOnScrollListener =
+        SnapOnScrollListener(snapHelper, behavior, onSnapPositionChangeListener)
+    addOnScrollListener(snapOnScrollListener)
+}
+
+fun SnapHelper.getSnapPosition(recyclerView: RecyclerView): Int {
+    val layoutManager = recyclerView.layoutManager ?: return RecyclerView.NO_POSITION
+    val snapView = findSnapView(layoutManager) ?: return RecyclerView.NO_POSITION
+    return layoutManager.getPosition(snapView)
 }

--- a/app/src/main/java/com/anliban/team/hippho/widget/SnapOnScrollListener.kt
+++ b/app/src/main/java/com/anliban/team/hippho/widget/SnapOnScrollListener.kt
@@ -1,0 +1,5 @@
+package com.anliban.team.hippho.widget
+
+/**
+ * Created by choejun-yeong on 24/04/2020.
+ */

--- a/app/src/main/java/com/anliban/team/hippho/widget/SnapOnScrollListener.kt
+++ b/app/src/main/java/com/anliban/team/hippho/widget/SnapOnScrollListener.kt
@@ -3,3 +3,48 @@ package com.anliban.team.hippho.widget
 /**
  * Created by choejun-yeong on 24/04/2020.
  */
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SnapHelper
+import com.anliban.team.hippho.util.getSnapPosition
+
+interface OnSnapPositionChangeListener {
+
+    fun onSnapPositionChange(position: Int)
+}
+
+class SnapOnScrollListener(
+    private val snapHelper: SnapHelper,
+    var behavior: Behavior = Behavior.NOTIFY_ON_SCROLL_STATE_IDLE,
+    var onSnapPositionChangeListener: OnSnapPositionChangeListener? = null
+) : RecyclerView.OnScrollListener() {
+
+    enum class Behavior {
+        NOTIFY_ON_SCROLL,
+        NOTIFY_ON_SCROLL_STATE_IDLE
+    }
+
+    private var snapPosition = RecyclerView.NO_POSITION
+
+    override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+        if (behavior == Behavior.NOTIFY_ON_SCROLL) {
+            maybeNotifySnapPositionChange(recyclerView)
+        }
+    }
+
+    override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+        if (behavior == Behavior.NOTIFY_ON_SCROLL_STATE_IDLE && newState == RecyclerView.SCROLL_STATE_IDLE
+        ) {
+            maybeNotifySnapPositionChange(recyclerView)
+        }
+    }
+
+    private fun maybeNotifySnapPositionChange(recyclerView: RecyclerView) {
+        val snapPosition = snapHelper.getSnapPosition(recyclerView)
+        val snapPositionChanged = this.snapPosition != snapPosition
+        if (snapPositionChanged) {
+            onSnapPositionChangeListener?.onSnapPositionChange(snapPosition)
+            this.snapPosition = snapPosition
+        }
+    }
+}

--- a/app/src/test/java/com/anliban/team/hippho/ui/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/anliban/team/hippho/ui/detail/DetailViewModelTest.kt
@@ -9,6 +9,7 @@ import com.anliban.team.hippho.data.ImageQueryOption
 import com.anliban.team.hippho.domain.DeleteImageUseCase
 import com.anliban.team.hippho.domain.GetImageByIdUseCase
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimUseCase
+import com.anliban.team.hippho.domain.detail.SwitchImageIndicatorUseCase
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionRequestParameters
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionUseCase
 import com.anliban.team.hippho.domain.model.GetImageRequestParameters
@@ -40,6 +41,9 @@ class DetailViewModelTest {
 
     @MockK(relaxed = true)
     lateinit var switchImagePositionUseCase: SwitchImagePositionUseCase
+
+    @MockK(relaxed = true)
+    lateinit var switchImageIndicatorUseCase : SwitchImageIndicatorUseCase
 
     lateinit var scaleImageAnimUseCase: ScaleImageAnimUseCase
 
@@ -209,6 +213,7 @@ class DetailViewModelTest {
         return DetailViewModel(
             getImageByDateUseCase,
             switchImagePositionUseCase,
+            switchImageIndicatorUseCase,
             scaleImageAnimUseCase,
             deleteImageUseCase,
             ids

--- a/app/src/test/java/com/anliban/team/hippho/ui/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/anliban/team/hippho/ui/detail/DetailViewModelTest.kt
@@ -9,6 +9,7 @@ import com.anliban.team.hippho.data.ImageQueryOption
 import com.anliban.team.hippho.domain.DeleteImageUseCase
 import com.anliban.team.hippho.domain.GetImageByIdUseCase
 import com.anliban.team.hippho.domain.detail.ScaleImageAnimUseCase
+import com.anliban.team.hippho.domain.detail.SwitchImageIndicatorRequestParameters
 import com.anliban.team.hippho.domain.detail.SwitchImageIndicatorUseCase
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionRequestParameters
 import com.anliban.team.hippho.domain.detail.SwitchImagePositionUseCase
@@ -43,7 +44,7 @@ class DetailViewModelTest {
     lateinit var switchImagePositionUseCase: SwitchImagePositionUseCase
 
     @MockK(relaxed = true)
-    lateinit var switchImageIndicatorUseCase : SwitchImageIndicatorUseCase
+    lateinit var switchImageIndicatorUseCase: SwitchImageIndicatorUseCase
 
     lateinit var scaleImageAnimUseCase: ScaleImageAnimUseCase
 
@@ -96,6 +97,29 @@ class DetailViewModelTest {
         val position = thumbnail.indexOf(thumbnail.find { it.image == selectedImage.image })
 
         assert(viewModel.moveToThumbnail.getOrAwaitValue().peekContent() == position)
+    }
+
+    @Test
+    fun `썸네일 스크롤시, 가로 이미지 리스트 구분자 이동`() = coroutineTestRule.testDispatcher.runBlockingTest {
+        val images = DummyData.images
+        val changedPosition = images.size - 1
+
+        val useCase = SwitchImageIndicatorUseCase()
+
+        val mockSelectedImage = MutableLiveData(images.mapDetailImageList())
+        val mockClickedId = MutableLiveData(images[0].id)
+        val selectedImageRequest = SwitchImageIndicatorRequestParameters(
+            position = changedPosition,
+            items = images.mapDetailImageList(),
+            clickedId = mockClickedId
+        )
+
+        useCase(selectedImageRequest, mockSelectedImage)
+
+        val mockSelected = mockSelectedImage.getOrAwaitValue()
+        val selectedPosition = mockSelected.indexOf(mockSelected.find { it.isSelected })
+
+        assert(changedPosition == selectedPosition)
     }
 
     @Test


### PR DESCRIPTION
- SnapOnScrollListener 등록 
- Thumbnail Rv : SmoothScroll 에서 Scroll 로 변경.
- SwitchImageIndicatorUseCase 구현  (SecondList Indicator 변경 로직)
- LinearSnapHelper -> PagerSnapHelper로 변경

closed #28 